### PR TITLE
Mailgun API endpoint param added

### DIFF
--- a/Mailer.php
+++ b/Mailer.php
@@ -52,6 +52,11 @@ class Mailer extends BaseMailer
     public $domain;
 
     /**
+     * @var string Mailgun endpoint.
+     */
+    public $endpoint = "api.mailgun.net";
+
+    /**
      * @var Mailgun Mailgun instance.
      */
     private $_mailgun;
@@ -95,6 +100,6 @@ class Mailer extends BaseMailer
         if (!$this->domain) {
             throw new InvalidConfigException('Mailer::domain must be set.');
         }
-        return new Mailgun($this->key);
+        return new Mailgun($this->key, $this->endpoint);
     }
 }


### PR DESCRIPTION
This parameter is needed to change the server, because not all accounts now work on the main server.