### PR TITLE
Implemented multiple emails

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -103,6 +103,7 @@ class Message extends BaseMessage
      */
     public function setTo($to)
     {
+        if (is_array($to)) $to = join(', ', $to);
         $this->getMessageBuilder()->addToRecipient($to);
 
         return $this;
@@ -122,6 +123,7 @@ class Message extends BaseMessage
      */
     public function setCc($cc)
     {
+        if (is_array($cc)) $cc = join(', ', $cc);
         $this->getMessageBuilder()->addCcRecipient($cc);
 
         return $this;
@@ -141,6 +143,7 @@ class Message extends BaseMessage
      */
     public function setBcc($bcc)
     {
+        if (is_array($bcc)) $bcc = join(', ', $bcc);
         $this->getMessageBuilder()->addBccRecipient($bcc);
 
         return $this;

--- a/src/Message.php
+++ b/src/Message.php
@@ -40,6 +40,7 @@ class Message extends BaseMessage
 
     /**
      * @inheritdoc
+     * @deprecated MailGun only supports UTF8
      */
     public function setCharset($charset)
     {
@@ -197,6 +198,7 @@ class Message extends BaseMessage
 
     /**
      * @inheritdoc
+     * @deprecated attachContent is not supported by MailGun
      */
     public function attachContent($content, array $options = [])
     {
@@ -215,6 +217,7 @@ class Message extends BaseMessage
 
     /**
      * @inheritdoc
+     * @deprecated embedContent is not supported by MailGun
      */
     public function embedContent($content, array $options = [])
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -259,7 +259,7 @@ class Message extends BaseMessage
         
         //Combien the emails
         $recipients = [];
-        foreach($recipients as $name => $email) {
+        foreach($emails as $name => $email) {
             if (is_numeric($name)) { 
                 $recipients[] = $email; 
             } else {

--- a/src/Message.php
+++ b/src/Message.php
@@ -103,8 +103,7 @@ class Message extends BaseMessage
      */
     public function setTo($to)
     {
-        if (is_array($to)) $to = join(', ', $to);
-        $this->getMessageBuilder()->addToRecipient($to);
+        $this->getMessageBuilder()->addToRecipient($this->prepareRecipients($to));
 
         return $this;
     }
@@ -123,8 +122,7 @@ class Message extends BaseMessage
      */
     public function setCc($cc)
     {
-        if (is_array($cc)) $cc = join(', ', $cc);
-        $this->getMessageBuilder()->addCcRecipient($cc);
+        $this->getMessageBuilder()->addCcRecipient($this->prepareRecipients($cc));
 
         return $this;
     }
@@ -143,8 +141,7 @@ class Message extends BaseMessage
      */
     public function setBcc($bcc)
     {
-        if (is_array($bcc)) $bcc = join(', ', $bcc);
-        $this->getMessageBuilder()->addBccRecipient($bcc);
+        $this->getMessageBuilder()->addBccRecipient($this->prepareRecipients($bcc));
 
         return $this;
     }
@@ -252,5 +249,25 @@ class Message extends BaseMessage
     protected function createMessageBuilder()
     {
         return new MessageBuilder;
+    }
+
+    /** Prepares the emails into an acceptable form.
+     * @return string comma seperated list of emails.
+     */
+    protected function prepareRecipients($emails) {
+        if (!is_array($emails)) return $emails;
+        
+        //Combien the emails
+        $recipients = [];
+        foreach($recipients as $name => $email) {
+            if (is_numeric($name)) { 
+                $recipients[] = $email; 
+            } else {
+                $recipients[] = "$name <$email>";
+            }
+        }
+
+        //Join it
+        return join(', ', $recipients);
     }
 }


### PR DESCRIPTION
The Yii2 documentation of the MessageInterface says that, like the from, the to, cc, and bcc take either a string or an array of emails. This PR adds that functionality to this library.

I have add a prepareRecipients function that will convert the email array into a string for Mailgun and implemented this function in `setTo`, `setCC` and `setBCC`.
