### PR TITLE
feat: attach file content

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -217,11 +217,23 @@ class Message extends BaseMessage
 
     /**
      * @inheritdoc
-     * @deprecated Attaching content is not supported by Mailgun.
      */
     public function attachContent($content, array $options = [])
     {
-        throw new NotSupportedException('Attaching content is not supported');
+        $attachmentName = !empty($options['fileName']) ? $options['fileName'] : null;
+        $message = $this->getMessageBuilder()->getMessage();
+
+        if (!isset($message['attachment'])) {
+            $message['attachment'] = [];
+        }
+
+        $message['attachment'][] = [
+            'fileContent' => $content,
+            'filename' => $attachmentName,
+        ];
+        $this->getMessageBuilder()->setMessage($message);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Hi @mikejpeters 

I found that we are able to attach 'fileContent':
https://github.com/mailgun/mailgun-php/blob/master/doc/attachments.md

Unfortunatelly there is no deditcated method in `Mailgun\Message\MessageBuilder.php` that's why I suggest to edit message directly in `boundstate\mailgun\Message.php`

